### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [travis]: https://travis-ci.org/lucashalbert/docker-rclone
 [microbadger]: https://microbadger.com/images/lucashalbert/docker-rclone
 [dockerstore]: https://store.docker.com/community/images/lucashalbert/docker-rclone
-# docker-rclone (Rclone v1.49.1)
+# docker-rclone (Rclone v1.49.2)
 A multi-architecture rclone image built on alpine linux. This image is compatible with arm32v6, arm32v7, arm64v8, and x86_64.
 
 ![Travis-CI Build Status](https://travis-ci.org/lucashalbert/docker-rclone.svg?branch=master)


### PR DESCRIPTION
Update README.md to reflect new version (v1.49.2) of Rclone.